### PR TITLE
feat: support overloaded functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ await token.unknownMethod(123); // compile error: Property 'unknownMethod' does 
 ## Known limitations
 
 - Only a small number of solidity types are supported. See more in [TODO section](#todo)
+- Function and events parameters and return names are not preserved (issues and PRs are welcome if you know how to make a named tuple from a mapped object)
 - It's impossible to use JSON ABI files because typescript does not allow importing JSON files `as const`. [Typescript issue](https://github.com/microsoft/TypeScript/issues/32063).
   To work this around:
 
@@ -57,8 +58,8 @@ await token.unknownMethod(123); // compile error: Property 'unknownMethod' does 
   - [ ] `struct`
   - [ ] arrays
 - [ ] Support for `contract.interface`
-- [ ] Support for functions:
-  - [ ] overloaded functions, e.g., `contract['fn()']` and `contract['fn(uint256)']`
+- [x] Support for functions:
+  - [x] overloaded functions, e.g., `contract['fn()']` and `contract['fn(uint256)']`
   - [x] methods directly on a contract. E.g., `contract.transfer`
   - [x] `.functions`, `.callStatic`, `.estimateGas`, and `.populateTransaction` buckets. E.g., `contract.functions.transfer`
 - [x] Support for events\*:

--- a/src/converter/event.ts
+++ b/src/converter/event.ts
@@ -1,14 +1,16 @@
 import { ethers } from "ethers";
 import { DeepReadonly, Merge, UnionToIntersection } from "ts-essentials";
-import { AbiItem, AbiToContract } from ".";
-import { ExpandObject, Join } from "../utils";
+import { AbiToContract } from ".";
+import { ExpandObject } from "../utils";
 import {
   AbiInputTypeToTypescriptType,
+  AbiItem,
+  AbiItemToSignature,
   AbiOutputTypeToTypescriptType,
   AbiVarType,
 } from "./types";
 
-type AbiEventVar = DeepReadonly<{
+export type AbiEventVar = DeepReadonly<{
   name: string;
   type: AbiVarType;
   indexed: boolean;
@@ -94,16 +96,6 @@ type AbiEventInputsToTypedEventObject<T extends readonly AbiEventVar[]> =
       }[number]
     >
   >;
-
-type AbiEventInputsToSignatureParameters<T extends readonly AbiEventVar[]> = [
-  ...{
-    [K in keyof T]: T[K] extends AbiEventVar ? T[K]["type"] : never;
-  }
-];
-type AbiItemToSignature<T extends AbiItemEvent> = `${T["name"]}(${Join<
-  AbiEventInputsToSignatureParameters<T["inputs"]>,
-  ","
->})`;
 
 type AbiItemToFilterFunction<T extends AbiItemEvent> = (
   ...args: [...AbiEventInputsToParameters<T["inputs"]>]

--- a/src/converter/index.ts
+++ b/src/converter/index.ts
@@ -1,22 +1,17 @@
 import { ethers } from "ethers";
-import { DeepReadonly, MergeN } from "ts-essentials";
+import { MergeN } from "ts-essentials";
 import { ExpandObject } from "../utils";
+import { AbiItemsToEventMethods, AbiItemsToFilters } from "./event";
 import {
-  AbiItemEvent,
-  AbiItemsToEventMethods,
-  AbiItemsToFilters,
-} from "./event";
-import {
-  AbiItemFunction,
   AbiItemsToCallStatic,
   AbiItemsToEstimateGas,
   AbiItemsToFunctions,
   AbiItemsToMethods,
   AbiItemsToPopulateTransaction,
 } from "./function";
+import { AbiItem } from "./types";
 
 // Main Converter
-export type AbiItem = DeepReadonly<AbiItemFunction | AbiItemEvent>;
 export type AbiToContract<T extends readonly AbiItem[]> = ExpandObject<
   MergeN<
     [

--- a/src/converter/types.ts
+++ b/src/converter/types.ts
@@ -1,8 +1,14 @@
 import { ethers } from "ethers";
-import { Tuple } from "ts-essentials";
+import { DeepReadonly, Tuple } from "ts-essentials";
+import { Join } from "../utils";
+import { AbiEventVar, AbiItemEvent } from "./event";
+import { AbiFunctionVar, AbiItemFunction } from "./function";
 
 export type AbiVarType = "address" | "string" | "uint256" | "int256" | "bool";
+export type AbiItem = DeepReadonly<AbiItemFunction | AbiItemEvent>;
+export type AbiVar = DeepReadonly<AbiFunctionVar | AbiEventVar>;
 
+// Abi Conversion Utils
 export type AbiInputTypeToTypescriptType<T extends AbiVarType> = {
   address: string;
   string: string;
@@ -19,7 +25,16 @@ export type AbiOutputTypeToTypescriptType<T extends AbiVarType> = {
   bool: boolean;
 }[T];
 
-// Abi Conversion Utils
+type AbiInputsToSignatureParameters<T extends readonly AbiVar[]> = [
+  ...{
+    [K in keyof T]: T[K] extends AbiVar ? T[K]["type"] : never;
+  }
+];
+export type AbiItemToSignature<T extends AbiItem> = `${T["name"]}(${Join<
+  AbiInputsToSignatureParameters<T["inputs"]>,
+  ","
+>})`;
+
 export type VoidOrSingleOrTuple<
   T extends Tuple,
   Unwrap extends boolean

--- a/src/typed-contract.ts
+++ b/src/typed-contract.ts
@@ -1,5 +1,6 @@
 import { ethers } from "ethers";
-import type { AbiItem, AbiToContract } from "./converter";
+import type { AbiToContract } from "./converter";
+import type { AbiItem } from "./converter/types";
 
 export const TypedContract: new <T extends readonly AbiItem[]>(
   addressOrName: string,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,3 +21,22 @@ export type Join<
   : T["length"] extends 1
   ? T[0]
   : `${Head<T>}${Sep}${Join<Tail<T>, Sep>}`;
+
+export type ArrayOmit<T extends any[], E> = T["length"] extends 0
+  ? []
+  : T extends [infer THead, ...infer TRest]
+  ? THead extends E
+    ? ArrayOmit<TRest, E>
+    : [THead, ...ArrayOmit<TRest, E>]
+  : never;
+
+declare const __VALUE_TO_OMIT__: unique symbol;
+export type __VALUE_TO_OMIT__ = typeof __VALUE_TO_OMIT__;
+export type Count<T extends readonly any[], E> = ArrayOmit<
+  [
+    ...{
+      [K in keyof T]: T[K] extends E ? T[K] : __VALUE_TO_OMIT__;
+    }
+  ],
+  __VALUE_TO_OMIT__
+>["length"];

--- a/test/TestAbi.ts
+++ b/test/TestAbi.ts
@@ -27,6 +27,10 @@ contract TestAbi {
     function pureArgsOneReturn(uint256 a, address b) external pure returns (uint256) {}
     function pureArgsTupleReturn(uint256 a, address b) external pure returns (uint256, address) {}
 
+    function overloaded() external {}
+    function overloaded(uint256 a) external {}
+    function overloaded(uint256 a, address b) external {}
+
     function differentTypes(address a, uint256 u, int256 i, bool b, string memory s) external {}
 }
 ```
@@ -203,6 +207,44 @@ export default <const>[
   {
     inputs: [],
     name: "noArgsNoReturn",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "overloaded",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "a",
+        type: "uint256",
+      },
+    ],
+    name: "overloaded",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "a",
+        type: "uint256",
+      },
+      {
+        internalType: "address",
+        name: "b",
+        type: "address",
+      },
+    ],
+    name: "overloaded",
     outputs: [],
     stateMutability: "nonpayable",
     type: "function",

--- a/test/generated/typechain/TestAbi.ts
+++ b/test/generated/typechain/TestAbi.ts
@@ -26,6 +26,7 @@ export interface TestAbiInterface extends utils.Interface {
     "argsTupleReturn(uint256,address)": FunctionFragment;
     "differentTypes(address,uint256,int256,bool,string)": FunctionFragment;
     "noArgsNoReturn()": FunctionFragment;
+    "overloaded()": FunctionFragment;
     "payableArgsNoReturn(uint256,address)": FunctionFragment;
     "payableArgsOneReturn(uint256,address)": FunctionFragment;
     "payableArgsTupleReturn(uint256,address)": FunctionFragment;
@@ -58,6 +59,10 @@ export interface TestAbiInterface extends utils.Interface {
   ): string;
   encodeFunctionData(
     functionFragment: "noArgsNoReturn",
+    values?: undefined
+  ): string;
+  encodeFunctionData(
+    functionFragment: "overloaded",
     values?: undefined
   ): string;
   encodeFunctionData(
@@ -129,6 +134,7 @@ export interface TestAbiInterface extends utils.Interface {
     functionFragment: "noArgsNoReturn",
     data: BytesLike
   ): Result;
+  decodeFunctionResult(functionFragment: "overloaded", data: BytesLike): Result;
   decodeFunctionResult(
     functionFragment: "payableArgsNoReturn",
     data: BytesLike
@@ -272,6 +278,21 @@ export interface TestAbi extends BaseContract {
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<ContractTransaction>;
 
+    "overloaded()"(
+      overrides?: Overrides & { from?: string | Promise<string> }
+    ): Promise<ContractTransaction>;
+
+    "overloaded(uint256)"(
+      a: BigNumberish,
+      overrides?: Overrides & { from?: string | Promise<string> }
+    ): Promise<ContractTransaction>;
+
+    "overloaded(uint256,address)"(
+      a: BigNumberish,
+      b: string,
+      overrides?: Overrides & { from?: string | Promise<string> }
+    ): Promise<ContractTransaction>;
+
     payableArgsNoReturn(
       a: BigNumberish,
       b: string,
@@ -366,6 +387,21 @@ export interface TestAbi extends BaseContract {
     overrides?: Overrides & { from?: string | Promise<string> }
   ): Promise<ContractTransaction>;
 
+  "overloaded()"(
+    overrides?: Overrides & { from?: string | Promise<string> }
+  ): Promise<ContractTransaction>;
+
+  "overloaded(uint256)"(
+    a: BigNumberish,
+    overrides?: Overrides & { from?: string | Promise<string> }
+  ): Promise<ContractTransaction>;
+
+  "overloaded(uint256,address)"(
+    a: BigNumberish,
+    b: string,
+    overrides?: Overrides & { from?: string | Promise<string> }
+  ): Promise<ContractTransaction>;
+
   payableArgsNoReturn(
     a: BigNumberish,
     b: string,
@@ -457,6 +493,19 @@ export interface TestAbi extends BaseContract {
     ): Promise<void>;
 
     noArgsNoReturn(overrides?: CallOverrides): Promise<void>;
+
+    "overloaded()"(overrides?: CallOverrides): Promise<void>;
+
+    "overloaded(uint256)"(
+      a: BigNumberish,
+      overrides?: CallOverrides
+    ): Promise<void>;
+
+    "overloaded(uint256,address)"(
+      a: BigNumberish,
+      b: string,
+      overrides?: CallOverrides
+    ): Promise<void>;
 
     payableArgsNoReturn(
       a: BigNumberish,
@@ -573,6 +622,21 @@ export interface TestAbi extends BaseContract {
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<BigNumber>;
 
+    "overloaded()"(
+      overrides?: Overrides & { from?: string | Promise<string> }
+    ): Promise<BigNumber>;
+
+    "overloaded(uint256)"(
+      a: BigNumberish,
+      overrides?: Overrides & { from?: string | Promise<string> }
+    ): Promise<BigNumber>;
+
+    "overloaded(uint256,address)"(
+      a: BigNumberish,
+      b: string,
+      overrides?: Overrides & { from?: string | Promise<string> }
+    ): Promise<BigNumber>;
+
     payableArgsNoReturn(
       a: BigNumberish,
       b: string,
@@ -665,6 +729,21 @@ export interface TestAbi extends BaseContract {
     ): Promise<PopulatedTransaction>;
 
     noArgsNoReturn(
+      overrides?: Overrides & { from?: string | Promise<string> }
+    ): Promise<PopulatedTransaction>;
+
+    "overloaded()"(
+      overrides?: Overrides & { from?: string | Promise<string> }
+    ): Promise<PopulatedTransaction>;
+
+    "overloaded(uint256)"(
+      a: BigNumberish,
+      overrides?: Overrides & { from?: string | Promise<string> }
+    ): Promise<PopulatedTransaction>;
+
+    "overloaded(uint256,address)"(
+      a: BigNumberish,
+      b: string,
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<PopulatedTransaction>;
 

--- a/test/generated/typechain/factories/TestAbi__factory.ts
+++ b/test/generated/typechain/factories/TestAbi__factory.ts
@@ -182,6 +182,44 @@ const _abi = [
     type: "function",
   },
   {
+    inputs: [],
+    name: "overloaded",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "a",
+        type: "uint256",
+      },
+    ],
+    name: "overloaded",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "a",
+        type: "uint256",
+      },
+      {
+        internalType: "address",
+        name: "b",
+        type: "address",
+      },
+    ],
+    name: "overloaded",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
     inputs: [
       {
         internalType: "uint256",

--- a/test/typed-contract.test.ts
+++ b/test/typed-contract.test.ts
@@ -94,6 +94,30 @@ assertType<
     TypechainTestAbi["functions"]["pureArgsTupleReturn"]
   >
 >();
+assertType<
+  Equals<
+    typeof typedContract["functions"]["differentTypes"],
+    TypechainTestAbi["functions"]["differentTypes"]
+  >
+>();
+assertType<
+  Equals<
+    typeof typedContract["functions"]["overloaded()"],
+    TypechainTestAbi["functions"]["overloaded()"]
+  >
+>();
+assertType<
+  Equals<
+    typeof typedContract["functions"]["overloaded(uint256)"],
+    TypechainTestAbi["functions"]["overloaded(uint256)"]
+  >
+>();
+assertType<
+  Equals<
+    typeof typedContract["functions"]["overloaded(uint256,address)"],
+    TypechainTestAbi["functions"]["overloaded(uint256,address)"]
+  >
+>();
 
 ////////////////
 // callStatic //
@@ -131,6 +155,30 @@ assertType<
     TypechainTestAbi["callStatic"]["pureArgsTupleReturn"]
   >
 >();
+assertType<
+  Equals<
+    typeof typedContract["callStatic"]["differentTypes"],
+    TypechainTestAbi["callStatic"]["differentTypes"]
+  >
+>();
+assertType<
+  Equals<
+    typeof typedContract["callStatic"]["overloaded()"],
+    TypechainTestAbi["callStatic"]["overloaded()"]
+  >
+>();
+assertType<
+  Equals<
+    typeof typedContract["callStatic"]["overloaded(uint256)"],
+    TypechainTestAbi["callStatic"]["overloaded(uint256)"]
+  >
+>();
+assertType<
+  Equals<
+    typeof typedContract["callStatic"]["overloaded(uint256,address)"],
+    TypechainTestAbi["callStatic"]["overloaded(uint256,address)"]
+  >
+>();
 
 /////////////////
 // estimateGas //
@@ -166,6 +214,30 @@ assertType<
   Equals<
     typeof typedContract["estimateGas"]["pureArgsTupleReturn"],
     TypechainTestAbi["estimateGas"]["pureArgsTupleReturn"]
+  >
+>();
+assertType<
+  Equals<
+    typeof typedContract["estimateGas"]["differentTypes"],
+    TypechainTestAbi["estimateGas"]["differentTypes"]
+  >
+>();
+assertType<
+  Equals<
+    typeof typedContract["estimateGas"]["overloaded()"],
+    TypechainTestAbi["estimateGas"]["overloaded()"]
+  >
+>();
+assertType<
+  Equals<
+    typeof typedContract["estimateGas"]["overloaded(uint256)"],
+    TypechainTestAbi["estimateGas"]["overloaded(uint256)"]
+  >
+>();
+assertType<
+  Equals<
+    typeof typedContract["estimateGas"]["overloaded(uint256,address)"],
+    TypechainTestAbi["estimateGas"]["overloaded(uint256,address)"]
   >
 >();
 
@@ -206,6 +278,30 @@ assertType<
   Equals<
     typeof typedContract["populateTransaction"]["pureArgsTupleReturn"],
     TypechainTestAbi["populateTransaction"]["pureArgsTupleReturn"]
+  >
+>();
+assertType<
+  Equals<
+    typeof typedContract["populateTransaction"]["differentTypes"],
+    TypechainTestAbi["populateTransaction"]["differentTypes"]
+  >
+>();
+assertType<
+  Equals<
+    typeof typedContract["populateTransaction"]["overloaded()"],
+    TypechainTestAbi["populateTransaction"]["overloaded()"]
+  >
+>();
+assertType<
+  Equals<
+    typeof typedContract["populateTransaction"]["overloaded(uint256)"],
+    TypechainTestAbi["populateTransaction"]["overloaded(uint256)"]
+  >
+>();
+assertType<
+  Equals<
+    typeof typedContract["populateTransaction"]["overloaded(uint256,address)"],
+    TypechainTestAbi["populateTransaction"]["overloaded(uint256,address)"]
   >
 >();
 


### PR DESCRIPTION
Support for overloaded functions. E.g., 
```ts
await contract["fn()"]()
await contract["fn(uint256,string)"](42, "hello world")
```